### PR TITLE
Fix bit type for MySQL

### DIFF
--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -41,6 +41,7 @@ func (m MysqlDriver) dataType(colDataType string) string {
 		"date":     "time.Time",
 		"datetime": "time.Time",
 		"decimal":  "float64",
+		"bit":      "uint64",
 	}
 	if fieldType, ok := kFieldTypes[strings.ToLower(colDataType)]; !ok {
 		return "string"


### PR DESCRIPTION
Bit type as a string doesn't work with MySQL. Changed to uint64.