### PR TITLE
Fix MySQL timestamp handling

### DIFF
--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -32,16 +32,17 @@ func (m MysqlDriver) LoadDatabaseSchema(dsnString, schema, tableNames string) (D
 
 func (m MysqlDriver) dataType(colDataType string) string {
 	kFieldTypes := map[string]string{
-		"bigint":   "int64",
-		"int":      "int",
-		"tinyint":  "int",
-		"char":     "string",
-		"varchar":  "string",
-		"blob":     "[]byte",
-		"date":     "time.Time",
-		"datetime": "time.Time",
-		"decimal":  "float64",
-		"bit":      "uint64",
+		"bigint":    "int64",
+		"int":       "int",
+		"tinyint":   "int",
+		"char":      "string",
+		"varchar":   "string",
+		"blob":      "[]byte",
+		"date":      "time.Time",
+		"datetime":  "time.Time",
+		"timestamp": "time.Time",
+		"decimal":   "float64",
+		"bit":       "uint64",
 	}
 	if fieldType, ok := kFieldTypes[strings.ToLower(colDataType)]; !ok {
 		return "string"


### PR DESCRIPTION
If we're using time.Time for 'date' and 'datetime' type we have to use it also for 'timestamp' - in other case there are "Scan error on column index 5: unsupported driver -> Scan pair: time.Time -> *string" error appeared