### PR TITLE
Pass col.IsNullable into template

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -83,6 +83,7 @@ func generateModel(dbName, tName string, schema drivers.TableSchema, config Code
 			Name:            toCapitalCase(col.ColumnName),
 			ColumnName:      col.ColumnName,
 			Type:            col.DataType,
+			IsNullable:      strings.ToUpper(col.IsNullable) == "YES",
 			JsonMeta:        fmt.Sprintf("`json:\"%s\"`", col.ColumnName),
 			IsPrimaryKey:    strings.ToUpper(col.ColumnKey) == "PRI",
 			IsUniqueKey:     strings.ToUpper(col.ColumnKey) == "UNI",
@@ -134,6 +135,7 @@ type ModelField struct {
 	ColumnName      string
 	Type            string
 	JsonMeta        string
+	IsNullable      bool
 	IsPrimaryKey    bool
 	IsUniqueKey     bool
 	IsIndexed       bool

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -76,6 +76,7 @@ func (m MysqlDriver) queryColumns(db *gmq.Db, dbName string, tables string, dbSc
 			ColumnKey:    col.ColumnKey,
 			Extra:        col.Extra,
 			Comment:      col.ColumnComment,
+			IsNullable:   col.IsNullable,
 		}
 		dbSchema[col.TableName] = append(dbSchema[col.TableName], sCol)
 		return true

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -125,6 +125,7 @@ func (p PostgresDriver) queryColumns(db *gmq.Db, dbName string, tables string, d
 			DataType:     p.dataType(col.DataType),
 			ColumnKey:    columnKey,
 			Extra:        extra,
+			IsNullable:   col.IsNullable,
 		}
 		dbSchema[col.TableName] = append(dbSchema[col.TableName], sCol)
 		return true

--- a/drivers/schema.go
+++ b/drivers/schema.go
@@ -15,6 +15,7 @@ type Column struct {
 	ColumnKey    string
 	Extra        string
 	Comment      string
+	IsNullable   string
 }
 
 type TableSchema []Column


### PR DESCRIPTION
Pass `IsNullable` into template to enable `sql.Null*` classes, or the [github.com/guregu/null](https://github.com/guregu/null) helper package.

Here is an example of a custom template that uses `sql.Null*`:

```
{{ define "header" }}
// Code generated by ModelQ using a self defined template fragments

package {{.PkgName}}

import (
	"encoding/json"
	"encoding/gob"
	"fmt"
	"strings"
	"database/sql"
	{{if .ImportTime}}"time"{{end}}
)
{{ end }}

{{ define "struct" }}
type {{.Name}} struct {
	{{range .Fields}}{{.Name}} {{template "nullable_type" .}} {{.JsonMeta}}
	{{end}}
}
{{ end }}

{{ define "obj_api" }}
{{ end }}

{{ define "query_api" }}
{{ end }}

{{ define "managed_api" }}
{{ end }}


{{ define "nullable_type" }}
    {{- if and .IsNullable (eq .Type "string") -}}
        sql.NullString
    {{- else if and .IsNullable (eq .Type "int") -}}
        sql.NullInt64
    {{- else if and .IsNullable (eq .Type "float") -}}
        sql.NullFloat
    {{- else if and .IsNullable (eq .Type "bool") -}}
        sql.NullBool
    {{- else -}}
        {{.Type}}
    {{- end -}}
{{ end }}
```

Here is an example that uses [github.com/guregu/null](https://github.com/guregu/null) and [sqlx](https://github.com/jmoiron/sqlx), similar to https://github.com/mijia/modelq/issues/17:

```
{{ define "header" }}
// Code generated by ModelQ using a self defined template fragments

package {{.PkgName}}

import (
	"encoding/json"
	"encoding/gob"
	"fmt"
	"strings"
	"database/sql"
	{{if .ImportTime}}"time"{{end}}
    
    "gopkg.in/guregu/null.v3"
)
{{ end }}

{{ define "struct" }}
type {{.Name}} struct {
	{{range .Fields}}{{.Name}} {{template "nullable_type" .}} `json:"{{.ColumnName}}" db:"{{.ColumnName}}"`
	{{end}}
}
{{ end }}

{{ define "obj_api" }}
{{ end }}

{{ define "query_api" }}
{{ end }}

{{ define "managed_api" }}
{{ end }}


{{ define "nullable_type" }}
    {{- if and .IsNullable (eq .Type "string") -}}
        null.String
    {{- else if and .IsNullable (eq .Type "int") -}}
        null.Int
    {{- else if and .IsNullable (eq .Type "float") -}}
        null.Float
    {{- else if and .IsNullable (eq .Type "bool") -}}
        null.Bool
    {{- else if and .IsNullable (eq .Type "time.Time") -}}
        null.Time
    {{- else -}}
        {{.Type}}
    {{- end -}}
{{ end }}
```