### PR TITLE
Fix code generated from table with no primary key

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -110,6 +110,7 @@ func generateModel(dbName, tName string, schema drivers.TableSchema, config Code
 		config:    config,
 	}
 	needTime := false
+	needFmt := false
 	for i, col := range schema {
 		field := ModelField{
 			Name:            toCapitalCase(col.ColumnName),
@@ -130,6 +131,7 @@ func generateModel(dbName, tName string, schema drivers.TableSchema, config Code
 		}
 		if field.IsPrimaryKey {
 			model.PrimaryFields = append(model.PrimaryFields, &field)
+			needFmt = true
 		}
 
 		if field.IsUniqueKey {
@@ -143,7 +145,7 @@ func generateModel(dbName, tName string, schema drivers.TableSchema, config Code
 		model.Fields[i] = field
 	}
 
-	if err := model.GenHeader(w, tmpl, needTime); err != nil {
+	if err := model.GenHeader(w, tmpl, needTime, needFmt); err != nil {
 		return fmt.Errorf("[%s] Fail to gen model header, %s", tName, err)
 	}
 	if err := model.GenStruct(w, tmpl); err != nil {
@@ -340,12 +342,13 @@ func (m ModelMeta) getTemplate(tmpl *template.Template, name string, defaultTmpl
 	return defaultTmpl
 }
 
-func (m ModelMeta) GenHeader(w *bufio.Writer, tmpl *template.Template, importTime bool) error {
+func (m ModelMeta) GenHeader(w *bufio.Writer, tmpl *template.Template, importTime, importFmt bool) error {
 	return m.getTemplate(tmpl, "header", tmHeader).Execute(w, map[string]interface{}{
 		"DbName":     m.DbName,
 		"TableName":  m.TableName,
 		"PkgName":    m.config.packageName,
 		"ImportTime": importTime,
+		"ImportFmt":  importFmt,
 	})
 }
 

--- a/templates.go
+++ b/templates.go
@@ -12,7 +12,7 @@ package {{.PkgName}}
 import (
 	"encoding/json"
 	"encoding/gob"
-	"fmt"
+	{{if .ImportFmt}}"fmt"{{end}}
 	"strings"
 	"github.com/mijia/modelq/gmq"
 	"database/sql"
@@ -43,7 +43,7 @@ func (obj {{.Name}}) Get(dbtx gmq.DbTx) ({{.Name}}, error) {
 		return obj, err
 	} else {
 		return result, nil	
-	}{{else}}return 0, gmq.ErrNoPrimaryKeyDefined{{end}}
+	}{{else}}return obj, gmq.ErrNoPrimaryKeyDefined{{end}}
 }
 
 func (obj {{.Name}}) Insert(dbtx gmq.DbTx) ({{.Name}}, error) {


### PR DESCRIPTION
Compilation was failing due to an unused import (fmt), and
an incorrect return value from Get().

This addresses https://github.com/mijia/modelq/issues/29