### PR TITLE
If the (mysql) model contains 'blob' columns, the generated code will…

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -187,6 +187,7 @@ func (f ModelField) ConverterFuncName() string {
 		"time.Time": "AsTime",
 		"float64":   "AsFloat64",
 		"bool":      "AsBool",
+                "[]byte":    "AsByteArray",
 	}
 	if c, ok := convertors[f.Type]; ok {
 		return c

--- a/gmq/package.go
+++ b/gmq/package.go
@@ -173,6 +173,10 @@ func AsTime(rb sql.RawBytes) time.Time {
 	return time.Now()
 }
 
+func AsByteArray(rb sql.RawBytes) []byte {
+       return []byte(rb)
+}
+
 var Debug bool
 
 func init() {


### PR DESCRIPTION
… not compile, because of similar errors:

    # github.com/mijia/modelq/ttt
    ./preferences.go:235: cannot use gmq.AsString(rb[i]) (type string) as type []byte in assignment

Blob columns are already (almost) returned as []byte. This change provides an "AsByteArray" function to map sql.RawBytes to []byte. With this change the same schema that fails above, will compile correctly.