### PR TITLE
Return null timestamp instead of misleading one if value is invalid

### DIFF
--- a/gmq/package.go
+++ b/gmq/package.go
@@ -176,7 +176,7 @@ func AsTime(rb sql.RawBytes) time.Time {
 		return t
 	}
 
-	return time.Now()
+	return time.Time{}
 }
 
 func AsByteArray(rb sql.RawBytes) []byte {


### PR DESCRIPTION
If the value stored in the database does not convert into a valid time, I believe we should return `time.Time{}` instead of `time.Now()` so that the caller can appropriately handle the invalid value rather than operate under the false assumption that its value is the current timestamp.